### PR TITLE
Refine README achievements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,56 @@
-# Profile
+# Sparsh Jain's Profile
+
+## Name
+Sparsh Jain
+
+## Skills
+
+### Boards
+- Arduino (5+ yrs)
+- ESP32 (5+ yrs)
+- STM32 (ongoing projects)
+- LEGO Mindstorms 51515 (3 yrs)
+- Raspberry Pi (2+ yrs)
+- PCB design (1+ yr)
+
+### Languages
+- C++ (5+ yrs)
+- HTML (3+ yrs)
+- Python (3+ yrs)
+- JavaScript (5 mos)
+- 3D modeling (3+ yrs)
+- Currently learning Assembly
+
+### 3D Modelling & Slicing Tools
+- Blender (2 yrs)
+- Tinkercad (3 yrs)
+- Anycubic Slicer (1 yr)
+- Orca Slicer (5 mos)
+- Prusa Slicer (1+ yr)
+
+### AI Model Training
+- Google Colab (2+ yrs)
+- Created 12 deep learning models and 20+ AI projects
+- Developing an RNN for CardioAlert
+
+## Achievements
+- National Automation Robotics Challenge 2024 – 1st place, ₹7,500
+- IEEE REPower 2024 – 3rd place with idea Bhoomi
+- Innovate H2O 2024 – Winner, ₹10,000 funding
+- Atal Marathon 2024 – Top 500, government funding and mentorship
+- Elixir 8.0 2024 – Contributed to school trophy
+- WRO – 2nd place in RoboMission
+- MCA Codenest 2025 – Winner
+- Green Pioneers 2025 – Potentially Most Impactful Project for Bhoomi, prizes worth ₹5,000
+- Biomimicry Build-a-thon 2025 – Honorable Mention, ₹1,000 prize
+- Student Hacks 2025 – Top 20 teams
+- Hack 4 Humanity 2024 – Honorable Mention
+- Fabguard Innovation Challenge – Winner, ₹5,000
+- Intel AI Fest – Completed AI for Entrepreneurship module
+- Raman Awards 2024 – National Qualifier for Neuroshield
+- Mega Hackathon 2025 – Sustainability Award for Bhoomi, prizes worth over $100
+- CodePie 2025 – S.A.I. 2nd place (hackathon), SafeSteps 2nd place (ideathon), NeuroShield top 10 (ideathon), Bhoomi top 20 (hackathon)
+- HackNexus – Top three prize, over ₹30,000
+- Byte Bash – 1st place for NeuroShield
+- HAP 2025 – 2nd place for CardioAlert
+- Total prize winnings – Over $1,000


### PR DESCRIPTION
## Summary
- shorten README by removing the projects list
- clarify CodePie wins for S.A.I., SafeSteps, NeuroShield, and Bhoomi
- mention HackNexus top-three prize, Byte Bash first place, and HAP 2025 second place

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686ab445b1488323a687f164c1120a92